### PR TITLE
Refactor Response in Connect Service

### DIFF
--- a/src/main/java/com/xfers/model/Connect.java
+++ b/src/main/java/com/xfers/model/Connect.java
@@ -1,54 +1,70 @@
 package com.xfers.model;
 
-import com.google.gson.Gson;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import com.xfers.exception.APIConnectionException;
 import com.xfers.exception.APIException;
 import com.xfers.exception.AuthenticationException;
 import com.xfers.exception.InvalidRequestException;
+import com.xfers.model.response.ConnectResponse;
 import com.xfers.net.APIResource;
+import com.xfers.serializer.SnakeToCamelDeserializer;
+
 import org.apache.commons.codec.digest.DigestUtils;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class Connect {
     private static final String resourceUrl = "/authorize";
 
-    public static Response getToken(Map<String, Object> params, String appKey, String secretKey)
+    /**
+     * After user receives the OTP SMS, merchant's app should capture the OTP and pass it to Xfers via this API.
+     * @return An instance of ConnectResponse, which contains the user's unique ID and user's API KEY.
+     * @param returnURL Optional parameter, fill with a null value if not needed.
+     */
+    public static ConnectResponse getToken(String phoneNumber, String OTP, String returnURL, String appKey, String secretKey)
             throws AuthenticationException, InvalidRequestException, APIException, APIConnectionException, UnirestException {
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("phone_no", phoneNumber);
+        params.put("otp", OTP);
+        params.put("signature", getSignature(phoneNumber, secretKey, OTP));
+        if (null != returnURL) {
+            params.put("return_url", returnURL);
+        }
+
         String url = resourceUrl + "/get_token";
-        String phoneNumber = (String) params.get("phone_no");
-        String OTP = (String) params.get("otp");
-
-        params.put("signature", getSignature(phoneNumber, secretKey, OTP) );
-
         String response = APIResource.requestConnect(APIResource.RequestMethod.GET, url, params, appKey);
-        Gson gson = new Gson();
-        return gson.fromJson(response, Response.class);
+        return SnakeToCamelDeserializer.create().fromJson(response, ConnectResponse.class);
     }
 
-    public static Response authorize(Map<String, Object> params, String appKey, String secretKey)
+    /**
+     * Register a new user and send an OTP to the phone number in parameter.
+     * @return A message whether it is success or not.
+     */
+    public static String authorize(String phoneNumber, String appKey, String secretKey)
             throws AuthenticationException, InvalidRequestException, APIException, APIConnectionException, UnirestException {
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("phone_no", phoneNumber);
+        params.put("signature", getSignature(phoneNumber, secretKey));
 
         String url = resourceUrl + "/signup_login";
-        String phoneNumber = (String) params.get("phone_no");
-        params.put("signature", getSignature(phoneNumber, secretKey) );
         String response = APIResource.requestConnect(APIResource.RequestMethod.POST, url, params, appKey);
-        Gson gson = new Gson();
-        return gson.fromJson(response, Response.class);
-
+        return SnakeToCamelDeserializer.create().fromJson(response, ConnectResponse.class).getMessage();
     }
 
-    public static Response privateAuthorize (Map<String, Object> params, String appKey, String secretKey)
+    /**
+     * Register a new user without the need of OTP or get the user API KEY.
+     * @return An instance of ConnectResponse, which contains the user's unique ID and user's API KEY. Ignore SignUpURL and WalletName.
+     */
+    public static ConnectResponse privateAuthorize(String phoneNumber, String appKey, String secretKey)
             throws AuthenticationException, InvalidRequestException, APIException, APIConnectionException, UnirestException {
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("phone_no", phoneNumber);
+        params.put("signature", getSignature(phoneNumber, secretKey));
 
-        String url = resourceUrl + "/private_wallet";
-        String phoneNumber = (String) params.get("phone_no");
-        params.put("signature", getSignature(phoneNumber, secretKey) );
+        String url = resourceUrl + "/signup_login";
         String response = APIResource.requestConnect(APIResource.RequestMethod.POST, url, params, appKey);
-        Gson gson = new Gson();
-        return gson.fromJson(response, Response.class);
-
+        return SnakeToCamelDeserializer.create().fromJson(response, ConnectResponse.class);
     }
 
     public static String validate_phone(String phoneNumber)

--- a/src/main/java/com/xfers/model/Connect.java
+++ b/src/main/java/com/xfers/model/Connect.java
@@ -62,7 +62,7 @@ public class Connect {
         params.put("phone_no", phoneNumber);
         params.put("signature", getSignature(phoneNumber, secretKey));
 
-        String url = resourceUrl + "/signup_login";
+        String url = resourceUrl + "/private_wallet";
         String response = APIResource.requestConnect(APIResource.RequestMethod.POST, url, params, appKey);
         return SnakeToCamelDeserializer.create().fromJson(response, ConnectResponse.class);
     }

--- a/src/main/java/com/xfers/model/response/ConnectResponse.java
+++ b/src/main/java/com/xfers/model/response/ConnectResponse.java
@@ -8,6 +8,7 @@ public class ConnectResponse {
     private String signUpUrl;
     private String walletName;
     private Boolean isFullyVerified;
+    private String otpProvided;
 
     public String getMessage() {
         return this.msg;
@@ -35,5 +36,9 @@ public class ConnectResponse {
 
     public Boolean isFullyVerified() {
         return this.isFullyVerified;
+    }
+
+    public String getOtpProvided() {
+        return this.otpProvided;
     }
 }

--- a/src/main/java/com/xfers/model/response/ConnectResponse.java
+++ b/src/main/java/com/xfers/model/response/ConnectResponse.java
@@ -4,11 +4,8 @@ public class ConnectResponse {
     private String msg;
     private String id;
     private String userApiToken;
-    private String currency;
     private String signUpUrl;
-    private String walletName;
     private Boolean isFullyVerified;
-    private String otpProvided;
 
     public String getMessage() {
         return this.msg;
@@ -22,23 +19,11 @@ public class ConnectResponse {
         return this.userApiToken;
     }
 
-    public String getCurrency() {
-        return this.currency;
-    }
-
     public String getSignUpUrl() {
         return this.signUpUrl;
     }
 
-    public String getWalletName() {
-        return this.walletName;
-    }
-
     public Boolean isFullyVerified() {
         return this.isFullyVerified;
-    }
-
-    public String getOtpProvided() {
-        return this.otpProvided;
     }
 }

--- a/src/main/java/com/xfers/model/response/ConnectResponse.java
+++ b/src/main/java/com/xfers/model/response/ConnectResponse.java
@@ -1,0 +1,39 @@
+package com.xfers.model.response;
+
+public class ConnectResponse {
+    private String msg;
+    private String id;
+    private String userApiToken;
+    private String currency;
+    private String signUpUrl;
+    private String walletName;
+    private Boolean isFullyVerified;
+
+    public String getMessage() {
+        return this.msg;
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public String getUserApiToken() {
+        return this.userApiToken;
+    }
+
+    public String getCurrency() {
+        return this.currency;
+    }
+
+    public String getSignUpUrl() {
+        return this.signUpUrl;
+    }
+
+    public String getWalletName() {
+        return this.walletName;
+    }
+
+    public Boolean isFullyVerified() {
+        return this.isFullyVerified;
+    }
+}

--- a/src/test/java/com/xfers/model/example/application/SampleLoan.java
+++ b/src/test/java/com/xfers/model/example/application/SampleLoan.java
@@ -3,7 +3,6 @@ package com.xfers.model.example.application;
 import com.xfers.Xfers;
 import com.xfers.model.BankAccount;
 import com.xfers.model.Connect;
-import com.xfers.model.Response;
 import com.xfers.model.User;
 import com.xfers.model.channeling.loan.Collateral;
 import com.xfers.model.channeling.loan.Customer;
@@ -16,6 +15,7 @@ import com.xfers.model.channeling.loan.response.CreateDisbursementResponse;
 import com.xfers.model.channeling.loan.response.CreateRepaymentResponse;
 import com.xfers.model.channeling.loan.response.GetDisbursementResponse;
 import com.xfers.model.channeling.loan.response.ListDisbursementResponse;
+import com.xfers.model.response.ConnectResponse;
 
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
@@ -97,13 +97,11 @@ public class SampleLoan {
      * will be used to identify the user onward
      */
     private static String exampleSignUp(String xfersAppApiKey, String xfersAppSecretKey, String phoneNumber) {
-        Map<String, Object> params = new HashMap<String, Object>();
-        params.put("phone_no", phoneNumber);
         try {
-            Response response = Connect.privateAuthorize(params, xfersAppApiKey, xfersAppSecretKey);
-            String userApiToken = response.getUserApiToken();
-            System.out.println("User API Token: " + userApiToken);
-            return userApiToken;
+            ConnectResponse response = Connect.privateAuthorize(phoneNumber, xfersAppApiKey, xfersAppSecretKey);
+            System.out.println("User API Token: " + response.getUserApiToken());
+            System.out.println("User ID: " + response.getId());
+            return response.getUserApiToken();
         } catch (Exception e) {
             System.out.println("Sign up error: " + e);
             return null;

--- a/src/test/java/com/xfers/model/example/application/SamplePrivateWallet.java
+++ b/src/test/java/com/xfers/model/example/application/SamplePrivateWallet.java
@@ -1,6 +1,5 @@
 package com.xfers.model.example.application;
 
-import com.google.gson.Gson;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import com.xfers.Xfers;
 import com.xfers.exception.APIConnectionException;
@@ -8,6 +7,7 @@ import com.xfers.exception.APIException;
 import com.xfers.exception.AuthenticationException;
 import com.xfers.exception.InvalidRequestException;
 import com.xfers.model.*;
+import com.xfers.model.response.ConnectResponse;
 
 import java.util.*;
 
@@ -176,9 +176,7 @@ public class SamplePrivateWallet {
         // start of the sign up process
         // this function should only be called once per user
         System.out.println("Authorizing");
-        Map<String, Object> params = new HashMap<String, Object>();
-        params.put("phone_no", phoneNumber); // this is a required field
-        Response response = Connect.privateAuthorize(params, xfersAppApiKey, xfersAppSecretKey);
+        ConnectResponse response = Connect.privateAuthorize(phoneNumber, xfersAppApiKey, xfersAppSecretKey);
         String userApiToken = response.getUserApiToken(); // save this value in database!
 
 

--- a/src/test/java/com/xfers/model/example/functional/ConnectExample.java
+++ b/src/test/java/com/xfers/model/example/functional/ConnectExample.java
@@ -15,7 +15,7 @@ public class ConnectExample {
 
         try {
             System.out.println("Authorizing");
-            String phoneNumber = "+6597288608";
+            String phoneNumber = "+65xxxxxxxx";
             String message = Connect.authorize(phoneNumber, xfersAppApiKey, xfersSecretApiKey);
             System.out.println(message);
         } catch (Exception e) {
@@ -24,7 +24,7 @@ public class ConnectExample {
 
         try {
             System.out.println("Getting token");
-            String phoneNumber = "+6597288608";
+            String phoneNumber = "+65xxxxxxxx";
             String OTP = "541231";
             String returnURL = "https://mywebsite.com/api/v3/account_registration/completed";
             ConnectResponse response = Connect.getToken(phoneNumber, OTP, returnURL, xfersAppApiKey, xfersSecretApiKey);
@@ -37,22 +37,13 @@ public class ConnectExample {
 
         try {
             System.out.println("Authorizing");
-            String phoneNumber = "+6597288608";
+            String phoneNumber = "+65xxxxxxxx";
             ConnectResponse response = Connect.privateAuthorize(phoneNumber, xfersAppApiKey, xfersSecretApiKey);
             System.out.println(response.getMessage());
             System.out.println(response.getUserApiToken());
         } catch (Exception e) {
             e.printStackTrace();
         }
-
-
-        try {
-
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
-
     }
 
     @Test
@@ -62,24 +53,23 @@ public class ConnectExample {
         String signup_signature;
 
         System.out.println("Testing create signature without OTP");
-        signup_signature = Connect.getSignature("+6597288608",xfersAppSecretKey);
-        assertEquals("b5e973032fc11b64245038376342cba7d1624593",signup_signature);
+        signup_signature = Connect.getSignature("+6588888888", xfersAppSecretKey);
+        assertEquals("8c8dc202904a6314c984179bd536c36f8b5a9d35", signup_signature);
 
         System.out.println("Testing create signature with OTP");
-        signup_signature = Connect.getSignature("+6597288608",xfersAppSecretKey, "541231");
-        assertEquals("ca57354ed306683b72dd689008fe6a23761ec67a",signup_signature);
+        signup_signature = Connect.getSignature("+6588888888", xfersAppSecretKey, "541231");
+        assertEquals("d6822e49286c049bbaac638cf1bd1db5bccfbd67", signup_signature);
 
         System.out.println("Testing create signature with phone number not properly written sg");
-        signup_signature = Connect.getSignature("97288608",xfersAppSecretKey, "541231");
-        assertEquals("ca57354ed306683b72dd689008fe6a23761ec67a",signup_signature);
+        signup_signature = Connect.getSignature("88888888", xfersAppSecretKey, "541231");
+        assertEquals("d6822e49286c049bbaac638cf1bd1db5bccfbd67", signup_signature);
 
         System.out.println("Testing create signature with phone number not properly written id");
-        signup_signature = Connect.getSignature("087785725657",xfersAppSecretKey, "541231");
-        assertEquals("ccd43bab5cf3ba9eb4be34b558e0880946ce0dae",signup_signature);
+        signup_signature = Connect.getSignature("087888888888", xfersAppSecretKey, "541231");
+        assertEquals("d021946467dd7c92dbc5031109d5eee5b8125171", signup_signature);
 
         System.out.println("Testing create signature with phone number not properly written id");
-        signup_signature = Connect.getSignature("+087785725657",xfersAppSecretKey, "541231");
-        assertEquals("ccd43bab5cf3ba9eb4be34b558e0880946ce0dae",signup_signature);
-
+        signup_signature = Connect.getSignature("+087888888888", xfersAppSecretKey, "541231");
+        assertEquals("d021946467dd7c92dbc5031109d5eee5b8125171", signup_signature);
     }
 }

--- a/src/test/java/com/xfers/model/example/functional/ConnectExample.java
+++ b/src/test/java/com/xfers/model/example/functional/ConnectExample.java
@@ -1,17 +1,11 @@
 package com.xfers.model.example.functional;
 
+import static org.junit.Assert.assertEquals;
+
 import com.xfers.Xfers;
 import com.xfers.model.Connect;
-import com.xfers.model.Response;
 import com.xfers.model.response.ConnectResponse;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 public class ConnectExample {
     public static void main(String[] args) {

--- a/src/test/java/com/xfers/model/example/functional/ConnectExample.java
+++ b/src/test/java/com/xfers/model/example/functional/ConnectExample.java
@@ -3,6 +3,7 @@ package com.xfers.model.example.functional;
 import com.xfers.Xfers;
 import com.xfers.model.Connect;
 import com.xfers.model.Response;
+import com.xfers.model.response.ConnectResponse;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,24 +21,20 @@ public class ConnectExample {
 
         try {
             System.out.println("Authorizing");
-            Map<String, Object> params = new HashMap<String, Object>();
-            params.put("phone_no", "+6597288608");
-            params.put("signature", "a4f001729fe3accdbb0d9cfaf3b49b0678a4c91b");
-            Response response = Connect.authorize(params, xfersAppApiKey, xfersSecretApiKey);
-            System.out.println(response.getMsg());
+            String phoneNumber = "+6597288608";
+            String message = Connect.authorize(phoneNumber, xfersAppApiKey, xfersSecretApiKey);
+            System.out.println(message);
         } catch (Exception e) {
             e.printStackTrace();
         }
 
         try {
             System.out.println("Getting token");
-            Map<String, Object> params = new HashMap<String, Object>();
-            params.put("otp", "541231");
-            params.put("phone_no", "+6597288608");
-            params.put("signature", "132e60cc2b6076824fac1ac4c1bb6b47cc3f9036");
-            params.put("return_url", "https://mywebsite.com/api/v3/account_registration/completed");
-            Response response = Connect.getToken(params, xfersAppApiKey, xfersSecretApiKey);
-            System.out.println(response.getMsg());
+            String phoneNumber = "+6597288608";
+            String OTP = "541231";
+            String returnURL = "https://mywebsite.com/api/v3/account_registration/completed";
+            ConnectResponse response = Connect.getToken(phoneNumber, OTP, returnURL, xfersAppApiKey, xfersSecretApiKey);
+            System.out.println(response.getMessage());
             System.out.println(response.getUserApiToken());
             System.out.println(response.getSignUpUrl());
         } catch (Exception e) {
@@ -46,11 +43,9 @@ public class ConnectExample {
 
         try {
             System.out.println("Authorizing");
-            Map<String, Object> params = new HashMap<String, Object>();
-            params.put("phone_no", "+6597288608");
-            params.put("signature", "a4f001729fe3accdbb0d9cfaf3b49b0678a4c91b");
-            Response response = Connect.privateAuthorize(params, xfersAppApiKey, xfersSecretApiKey);
-            System.out.println(response.getMsg());
+            String phoneNumber = "+6597288608";
+            ConnectResponse response = Connect.privateAuthorize(phoneNumber, xfersAppApiKey, xfersSecretApiKey);
+            System.out.println(response.getMessage());
             System.out.println(response.getUserApiToken());
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
3 APIs are affected:
1. `signup_login` needs `msg` only.
2. `get_token` needs `msg`, `otp_provided` on some occasion, phase_one response, or phase_two response.
3. `private_wallet` needs `msg`, phase_one response, or phase_two response.

phase_one and phase_two responses contains `msg`, `id`, and `user_api_token`. They also contains either `sign_up_url` and `wallet_name`, or `is_fully_verified`.

Because of that, the connect response will contains `msg`, `otp_provided`, `id`, `user_api_token`, `sign_up_url`, `wallet_name`, and `is_fully_verified`.

EDIT:
`wallet_name` and `otp_provided` is not used, so they should be removed.
Because of that, the connect response will contains `msg`, `id`, `user_api_token`, `sign_up_url`, and `is_fully_verified`.
